### PR TITLE
Iss007 track time of data retrieval

### DIFF
--- a/src/extract.py
+++ b/src/extract.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import re
 from typing import Optional
 import warnings
 
@@ -36,10 +37,19 @@ class CDEAPI:
             )
 
     def get(self, api_call: str) -> dict:
-        formatted_api_call = f"{api_call}?API_KEY={self.api_key}"
+        if "?" in api_call:
+            join_char = "&"
+        else:
+            join_char = "?"
+        formatted_api_call = f"{api_call}{join_char}API_KEY={self.api_key}"
         resp = requests.get(formatted_api_call)
         resp.raise_for_status()
         return resp.json()
+
+    def _add_retrieved_at_time(self, df: pd.DataFrame) -> pd.DataFrame:
+        retrieved_at = pd.Timestamp.now(tz="utc").floor("s")
+        df["retrieved_at"] = retrieved_at
+        return df
 
     def get_state_oris(self, state: str) -> pd.DataFrame:
         api_call = f"{self.base_url}/agency/byStateAbbr/{state.upper()}"
@@ -52,4 +62,45 @@ class CDEAPI:
         with warnings.catch_warnings():
             # TODO: pandas 2.1.0 has a FutureWarning for concatenating DataFrames with Null entries
             warnings.filterwarnings("ignore", category=FutureWarning)
-            return pd.concat([df for df in county_oris if not df.empty], ignore_index=True)
+            ori_df = pd.concat([df for df in county_oris if not df.empty], ignore_index=True)
+        return self._add_retrieved_at_time(ori_df)
+
+    def _check_to_from_str(self, to_from: str) -> None:
+        pattern = re.compile(r"^(([0]\d)|([1][0-2]))-((199[1-9])|(20[0-3]\d))$")
+        if not re.match(pattern, to_from):
+            raise ValueError(
+                "Incorrect format. Resubmit the given month-year string in mm-yyyy format."
+            )
+        else:
+            today = pd.Timestamp.now(tz="utc").floor("D")
+            year = int(to_from[3:])
+            month = int(to_from[:2])
+            if year > today.year or (year == today.year and month >= today.month):
+                raise ValueError(
+                    "Future month-year string given. Data from the future not yet available."
+                )
+
+    def _fmt_nibrs_agency_ori_offense_call(
+        self, ori: str, type: str, from_date: str, to_date: str, offense: str
+    ) -> str:
+        valid_types = ("counts", "totals")
+        valid_offenses = ("all", "11")
+        if type not in valid_types:
+            raise ValueError(
+                "Received an invalid 'type' value for this API endpoint. "
+                f"Valid values: {valid_types}"
+            )
+        if offense not in valid_offenses:
+            raise ValueError(
+                "Received an invalid 'offense' value for this API endpoint. "
+                f"Valid values: {valid_offenses}"
+            )
+        self._check_to_from_str(from_date)
+        self._check_to_from_str(to_date)
+        if pd.to_datetime(from_date) > pd.to_datetime(to_date):
+            raise ValueError("The `to` date cannot predate the 'from' date.")
+        api_call = (
+            f"{self.base_url}/nibrs/agency/{{ori}}/{offense}?type={type}&"
+            f"from={from_date}&to={to_date}&ori={ori}"
+        )
+        return api_call

--- a/src/extract.py
+++ b/src/extract.py
@@ -71,14 +71,14 @@ class CDEAPI:
             raise ValueError(
                 "Incorrect format. Resubmit the given month-year string in mm-yyyy format."
             )
-        else:
-            today = pd.Timestamp.now(tz="utc").floor("D")
-            year = int(to_from[3:])
-            month = int(to_from[:2])
-            if year > today.year or (year == today.year and month >= today.month):
-                raise ValueError(
-                    "Future month-year string given. Data from the future not yet available."
-                )
+        # else:
+        #     today = pd.Timestamp.now(tz="utc").floor("D")
+        # year = int(to_from[3:])
+        # month = int(to_from[:2])
+        # if year > today.year or (year == today.year and month >= today.month):
+        #     raise ValueError(
+        #         "Future month-year string given. Data from the future not yet available."
+        #     )
 
     def _fmt_nibrs_agency_ori_offense_call(
         self, ori: str, type: str, from_date: str, to_date: str, offense: str
@@ -100,7 +100,7 @@ class CDEAPI:
         if pd.to_datetime(from_date) > pd.to_datetime(to_date):
             raise ValueError("The `to` date cannot predate the 'from' date.")
         api_call = (
-            f"{self.base_url}/nibrs/agency/{{ori}}/{offense}?type={type}&"
+            f"{self.base_url}/nibrs/agency/{ori}/{offense}?type={type}&"
             f"from={from_date}&to={to_date}&ori={ori}"
         )
         return api_call


### PR DESCRIPTION
Changes:
* Adds a step to add the time of retrieval of data from the API. Closes #7 
* Adds a method to format the API call for the `https://api.usa.gov/crime/fbi/cde/nibrs/agency/...` API endpoint, although it's not fully baked. The FBI's documentation for that endpoint is wrong and I've only corrected one of the defects. I'm putting a pin in this for now and pivot to building tooling to ingest master data files.